### PR TITLE
MAINT: stats: move shortcut calculation of `mu3` where it belongs

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5971,9 +5971,9 @@ class kappa3_gen(rv_continuous):
     def _stats(self, a):
         outputs = [None if np.any(i < a) else np.nan for i in range(1, 5)]
         return outputs[:]
-    
+
     def _mom1_sc(self, m, *args):
-        if np.any(np.array(args) >= m):
+        if np.any(m >= args[0]):
             return np.nan
         return integrate.quad(self._mom_integ1, 0, 1, args=(m,)+args)[0]
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1151,14 +1151,6 @@ class rv_generic:
                                               **{'moments': moments})
             else:
                 mu, mu2, g1, g2 = self._stats(*goodargs)
-            if g1 is None:
-                mu3 = None
-            else:
-                if mu2 is None:
-                    mu2 = self._munp(2, *goodargs)
-                if g2 is None:
-                    # (mu2**1.5) breaks down for nan and inf
-                    mu3 = g1 * np.power(mu2, 1.5)
 
             if 'm' in moments:
                 if mu is None:
@@ -1174,7 +1166,7 @@ class rv_generic:
                         mu = self._munp(1, *goodargs)
                     # if mean is inf then var is also inf
                     with np.errstate(invalid='ignore'):
-                        mu2 = np.where(np.isfinite(mu), mu2p - mu**2, np.inf)
+                        mu2 = np.where(~np.isinf(mu), mu2p - mu**2, np.inf)
                 out0 = default.copy()
                 place(out0, cond, mu2 * scale * scale)
                 output.append(out0)
@@ -1202,6 +1194,11 @@ class rv_generic:
                     if mu2 is None:
                         mu2p = self._munp(2, *goodargs)
                         mu2 = mu2p - mu * mu
+                    if g1 is None:
+                        mu3 = None
+                    else:
+                        # (mu2**1.5) breaks down for nan and inf
+                        mu3 = g1 * np.power(mu2, 1.5)
                     if mu3 is None:
                         mu3p = self._munp(3, *goodargs)
                         with np.errstate(invalid='ignore'):


### PR DESCRIPTION
#### Reference issue
scipy/scipy#15140

#### What does this implement/fix?
There is a shortcut for calculating `mu3` in `rv_continuous.stats` that is out of place. The value isn't used until calculating kurtosis, so move it down there so that:

- It is only calculated if needed
- All other calculations it relies on have already been performed

This also makes some of the other fixes discussed in scipy/scipy#15140
